### PR TITLE
오류 DTO, 비밀번호 암호화, 예외 처리 설정 및 구현

### DIFF
--- a/src/main/java/com/mjuteam2/TeamOne/common/EncryptManager.java
+++ b/src/main/java/com/mjuteam2/TeamOne/common/EncryptManager.java
@@ -1,0 +1,34 @@
+package com.mjuteam2.TeamOne.common;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * 비밀번호 암호화
+ */
+public class EncryptManager {
+
+    public static String hash(String str) {
+        try {
+
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(str.getBytes());
+            byte[] byteData = md.digest();
+            StringBuffer hexString = new StringBuffer();
+            for (byte b : byteData) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0');
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+
+    public static boolean check(String password, String hashed) {
+        String encryptedPassword = EncryptManager.hash(password);
+        return hashed.equals(encryptedPassword);
+    }
+
+}

--- a/src/main/java/com/mjuteam2/TeamOne/common/dto/ApiResponse.java
+++ b/src/main/java/com/mjuteam2/TeamOne/common/dto/ApiResponse.java
@@ -1,9 +1,10 @@
 package com.mjuteam2.TeamOne.common.dto;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-@Getter
+@Getter @AllArgsConstructor
 public class ApiResponse<T> {
 
     public static <T> ResponseEntity<T> success(T body) {
@@ -21,6 +22,7 @@ public class ApiResponse<T> {
     public static <T> ResponseEntity<T> badRequest(T body) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
+
 
     public static <T> ResponseEntity<T> forbidden(T body) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);

--- a/src/main/java/com/mjuteam2/TeamOne/common/error/ErrorCode.java
+++ b/src/main/java/com/mjuteam2/TeamOne/common/error/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.mjuteam2.TeamOne.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter @AllArgsConstructor
+public class ErrorCode {
+    public static final String COMMON_ERROR = "common";
+
+    /**
+     * 회원가입 오류 (임시)
+     */
+    public static final String SIGN_UP_ERROR = "signUp";
+    public static final String AUTH_TOKEN_ERROR = "authToken";
+    public static final String VALIDATION_ERROR = "validation";
+
+}

--- a/src/main/java/com/mjuteam2/TeamOne/common/error/ErrorDto.java
+++ b/src/main/java/com/mjuteam2/TeamOne/common/error/ErrorDto.java
@@ -1,0 +1,27 @@
+package com.mjuteam2.TeamOne.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.validation.FieldError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter @AllArgsConstructor
+public class ErrorDto {
+
+    private String code;
+    private String message;
+
+    public static ErrorDto convertJson(FieldError error) {
+        return new ErrorDto(ErrorCode.VALIDATION_ERROR, error.getDefaultMessage());
+    }
+
+    public static ArrayList<ErrorDto> convertJson(List<FieldError> bindingResults) {
+        ArrayList<ErrorDto> result = new ArrayList<>();
+        for (FieldError e : bindingResults) {
+            result.add(ErrorDto.convertJson(e));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/mjuteam2/TeamOne/member/domain/Member.java
+++ b/src/main/java/com/mjuteam2/TeamOne/member/domain/Member.java
@@ -32,7 +32,7 @@ public class Member {
     private String introduce; // 간략 자기소개
 
     @Column(name = "token")
-    private String signUpToken;
+    private String authToken;
 
     @Enumerated(EnumType.STRING)
     private MemberType memberType;
@@ -51,7 +51,7 @@ public class Member {
 
 
     @Builder
-    public Member(String userId, String password, String email, String userName, String department, String schoolId, String phoneNumber, String nickname, String signUpToken, MemberType memberType) {
+    public Member(String userId, String password, String email, String userName, String department, String schoolId, String phoneNumber, String nickname, String authToken, MemberType memberType) {
         this.userId = userId;
         this.password = password;
         this.email = email;
@@ -60,7 +60,7 @@ public class Member {
         this.schoolId = schoolId;
         this.phoneNumber = phoneNumber;
         this.nickname = nickname;
-        this.signUpToken = signUpToken;
+        this.authToken = authToken;
         this.memberType = memberType;
     }
 

--- a/src/main/java/com/mjuteam2/TeamOne/member/dto/EmailDto.java
+++ b/src/main/java/com/mjuteam2/TeamOne/member/dto/EmailDto.java
@@ -4,12 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter @AllArgsConstructor
-public class EmailResponse {
-    public enum EmailProcessResult {
-        SUCCESS, FAIL
-    }
+public class EmailDto {
     String userEmail;
     String authToken;
-    EmailProcessResult emailProcessResult;
-    String message;
 }

--- a/src/main/java/com/mjuteam2/TeamOne/member/dto/SignUpForm.java
+++ b/src/main/java/com/mjuteam2/TeamOne/member/dto/SignUpForm.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
@@ -47,23 +46,23 @@ public class SignUpForm {
     private String email;
 
     @NotEmpty
-    private String signUpToken;
+    private String authToken;
 
     public boolean passwordCheck() {
         return password.equals(passwordCheck);
     }
 
-    public Member toMember() {
+    public Member toMember(String encryptedPassword) {
         return Member.builder()
                 .userId(this.id)
                 .userName(this.userName)
-                .password(this.password)
+                .password(encryptedPassword)
                 .email(this.email)
                 .nickname(this.nickname)
                 .phoneNumber(this.phoneNumber)
                 .department(this.department)
                 .schoolId(this.schoolId)
-                .signUpToken(this.signUpToken)
+                .authToken(this.authToken)
                 .memberType(MemberType.USER)
                 .build();
     }

--- a/src/main/java/com/mjuteam2/TeamOne/member/exception/SignUpException.java
+++ b/src/main/java/com/mjuteam2/TeamOne/member/exception/SignUpException.java
@@ -3,6 +3,7 @@ package com.mjuteam2.TeamOne.member.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+// 중복 이메일, 비밀번호 확인, 인증 메일 보내는거 관련 예외 총괄
 @ResponseStatus(code = HttpStatus.BAD_REQUEST)
 public class SignUpException extends RuntimeException{
     public SignUpException(String message) {

--- a/src/main/java/com/mjuteam2/TeamOne/member/service/SignUpService.java
+++ b/src/main/java/com/mjuteam2/TeamOne/member/service/SignUpService.java
@@ -1,6 +1,7 @@
 package com.mjuteam2.TeamOne.member.service;
 
 
+import com.mjuteam2.TeamOne.common.EncryptManager;
 import com.mjuteam2.TeamOne.member.exception.SignUpException;
 import com.mjuteam2.TeamOne.member.domain.Member;
 import com.mjuteam2.TeamOne.member.repository.MemberRepository;
@@ -23,14 +24,14 @@ public class SignUpService {
     private final MemberRepository memberRepository;
     private Map<String, String> authTokenStorage = new ConcurrentHashMap<>();
 
-    public Member signUp(SignUpForm form) throws Exception {
+    public Member signUp(SignUpForm form) {
         if (memberRepository.existsByEmail(form.getEmail())) {
             throw new SignUpException("이미 가입한 이메일입니다.");
         }
         if (!form.passwordCheck()) {
             throw new SignUpException("비밀번호를 다시 확인해주세요.");
         }
-        Member newMember = form.toMember();
+        Member newMember = form.toMember(EncryptManager.hash(form.getPassword()));
         memberRepository.save(newMember);
         log.info("new member signed up = {}", newMember);
         return newMember;

--- a/src/test/java/com/mjuteam2/TeamOne/EncryptManagerTest.java
+++ b/src/test/java/com/mjuteam2/TeamOne/EncryptManagerTest.java
@@ -1,0 +1,20 @@
+package com.mjuteam2.TeamOne;
+
+import com.mjuteam2.TeamOne.common.EncryptManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class EncryptManagerTest {
+
+    @Test
+    void hash() {
+        String password = "asdf1234";
+        String hashed = EncryptManager.hash(password);
+        System.out.println(hashed);
+
+        boolean result = EncryptManager.check(password, hashed);
+        Assertions.assertThat(result).isEqualTo(true);
+    }
+}

--- a/src/test/java/com/mjuteam2/TeamOne/SignUpServiceTest.java
+++ b/src/test/java/com/mjuteam2/TeamOne/SignUpServiceTest.java
@@ -34,8 +34,8 @@ public class SignUpServiceTest {
                 .password("tester1234")
                 .passwordCheck("tester1234")
                 .phoneNumber("010-1234-1234")
-                .signUpToken("ASDFASDF")
-                .schoolId(60171442)
+                .authToken("ASDFASDF")
+                .schoolId("60171442")
                 .build();
 
         // when
@@ -58,8 +58,8 @@ public class SignUpServiceTest {
                 .password("tester1234")
                 .passwordCheck("tester1234")
                 .phoneNumber("010-1234-1234")
-                .signUpToken("ASDFASDF")
-                .schoolId(60171442)
+                .authToken("ASDFASDF")
+                .schoolId("60171442")
                 .build();
         SignUpForm form2 = SignUpForm.builder()
                 .nickname("테스터2")
@@ -70,8 +70,8 @@ public class SignUpServiceTest {
                 .password("tester1234")
                 .passwordCheck("tester1234")
                 .phoneNumber("010-1234-1234")
-                .signUpToken("ASDFASDF")
-                .schoolId(60171442)
+                .authToken("ASDFASDF")
+                .schoolId("60171442")
                 .build();
 
         // 중복 이메일이면 예외가 발생함 (발생해야지 테스트 성공)
@@ -93,8 +93,8 @@ public class SignUpServiceTest {
                 .password("tester1234")
                 .passwordCheck("1111")
                 .phoneNumber("010-1234-1234")
-                .signUpToken("ASDFASDF")
-                .schoolId(60171442)
+                .authToken("ASDFASDF")
+                .schoolId("60171442")
                 .build();
 
         // 비밀번호 확인이 다르기 때문에 예외가 발생해야함


### PR DESCRIPTION
검증 오류나 예외 처리 후 응답 내릴때 에러코드는 일단 임시로 해당 오류나 예외를 식별할 수 있는 문자열로 설정해 놨습니다.
자세한건 회의 후 결정하도록 해요.

DB에 회원 비밀번호를 저장할 때 해쉬를 거쳐, 암호화를 한 뒤 저장하도록 구현했습니다.